### PR TITLE
Add runtime migration execution

### DIFF
--- a/src/WebUI/Program.cs
+++ b/src/WebUI/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Codidact.WebUI
 {
@@ -12,6 +13,11 @@ namespace Codidact.WebUI
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.AddConsole();
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();


### PR DESCRIPTION
Closes #17.

Migrations are applied as part of the `Startup` `Configure` method.