### PR TITLE
Add install instructions for Linux and adapt the instructions for Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,8 @@ Alternatively, if you don't want to run Visual Studio just to start the project,
 (so that `WebUI.csproj` is in your working directory) and issue the command `dotnet run`.
 
 #### Linux
-1. [Download .NET Core SDK](https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1904). Specifically,
-   from this page, follow the sections labeled "Register Microsoft Key and feed" and "Install the .NET Core SDK"
-2. Once the installation is complete, clone/download the repository and extract it somewhere.
-3. You can run Codidact by navigating to the src/WebUI folder (so that `WebUI.csproj` is in your working directory) and issuing
-   the command `dotnet run`.
+
+[You can find instructions here][1].
 
 #### Database Setup
 These instructions assume that you don't have a PostgreSQL DB server installed at the moment
@@ -82,3 +79,5 @@ and would like to run one locally. These instructions may change heavily dependi
 ## Contributions
 Very welcome! Please read our [contributing guidelines](https://github.com/codidact/core/blob/develop/CONTRIBUTING.md) before
 you start writing code.
+
+  [1]: docs/linux-instructions.md

--- a/README.md
+++ b/README.md
@@ -25,53 +25,7 @@ for everyone to use. The software will also be available to download and run you
 rules.
 
 ## Installation
-These instructions are for setting up and running a local development instance of Codidact.
-
-#### Technology Stack
-A list of the current tech stack is [here](https://github.com/codidact/docs/wiki/Technology-Stack).
-These items will be installed in the steps below, but if all of these are already installed on your
-system you can skip straight to running the project.
-
-#### Windows
-We'll be using Visual Studio for this setup.
-
-1. [Download Visual Studio 2019 Community](https://visualstudio.microsoft.com/downloads/) and start up the installer. If you
-   already have VS2019 installed, run the Visual Studio Installer instead.
-2. When prompted to select workloads, select the "ASP.NET and Web Development" workload, and then install it.
-3. Once the installation is complete, clone/download this repository and extract it somewhere.
-4. In the root of the repository, open the `Codidact.sln` file with visual studio to get started.
-5. Visual Studio will attempt to install any missing packages. This usually requires no additional action, *but if it fails to do so, 
-   [perform a package restore](https://docs.microsoft.com/en-US/nuget/consume-packages/package-restore).*
-6. Once Visual Studio has finished loading, you can run Codidact by setting the WebUI project as the startup project. You'll
-   know you're ready to run the project when a Start IIS Express button appears.
-7. See the Database Setup instructions below
-
-Alternatively, if you don't want to run Visual Studio just to start the project, you can navigate to the src/WebUI folder
-(so that `WebUI.csproj` is in your working directory) and issue the command `dotnet run`.
-
-#### Linux
-
-[You can find instructions here][1].
-
-#### Database Setup
-These instructions assume that you don't have a PostgreSQL DB server installed at the moment
-and would like to run one locally. These instructions may change heavily depending on your circumstances.
-
-1. Install PostgreSQL:
-    * [Windows](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). This will also install pgAdmin.
-    * Linux users will most likely want to use the PostgreSQL version provided by their package manager.
-2. Create a new database and name it whatever you like. Windows users can do this using pgAdmin.
-3. Open `appsettings.Development.json` in the WebUI project and add a new connection string for your database. It will look
-   something like this, along with any relevant connection information:
-```
-"ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=YOUR_DATABASE;"
-}
-```
-4. Open a terminal at the Codidact solution folder. Run the command `dotnet tool restore`.
-5. Navigate to the WebUI project folder and run `dotnet ef database update` to apply the project migrations to the database.
-6. Verify that your database is now populated with new tables.
-
+There are install instructions for [Windows][1] and [Linux][2].
 
 ## License
 [AGPL v3.0](https://github.com/codidact/core/blob/develop/LICENSE).
@@ -80,4 +34,5 @@ and would like to run one locally. These instructions may change heavily dependi
 Very welcome! Please read our [contributing guidelines](https://github.com/codidact/core/blob/develop/CONTRIBUTING.md) before
 you start writing code.
 
-  [1]: docs/linux-instructions.md
+  [1]: docs/windows-instructions.md
+  [2]: docs/linux-instructions.md

--- a/docs/linux-instructions.md
+++ b/docs/linux-instructions.md
@@ -30,6 +30,8 @@
 ## Installation using Visual Studio Code
 
  1. Install the [.NET Core SDK][2] you need version 3.1, some package managers have a package for this.
+    *Note. On Arch Linux you need to install both the `dotnet-sdk` and `aspnet-runtime` packages,
+    other package managers might divide this functionality too.*
 
  2. Install [Visual Studio Code][3]. You need the official version from Microsoft, the debugger
     for C# isn't included in packages from your package manager.

--- a/docs/linux-instructions.md
+++ b/docs/linux-instructions.md
@@ -1,0 +1,99 @@
+# Setup a Development Environment on Linux
+
+## Requisites
+
+ 1. Install the [.NET Core 3.1][2] framework, make sure to check if your package manager ships this version.
+
+ 2. Install [Postgres 12 or newer][4].
+
+ 3. (optional) Install [Visual Studio Code][3], this is a text editor which works really well with C#
+    on Linux.
+
+## Setup the Database
+
+ 1. Login as `postgres` user, this is usally done by executing `sudo -iu postgres`.
+
+ 2. Create a new user by executing `createuser codidact` you can choose any name here.
+
+ 3. Create a new database by executing `createdb --owner codidact codidact` you can choose any name here.
+
+ 4. Perpare a connection string by inserting your parameters into the format
+    `Host=localhost;Database=<database>;Username=<username>`, this is needed later. In the example above,
+    the connection string would be `Host=localhost;Database=codidact;Username=codidact`.
+
+ 5. You can logout using `logout`.
+
+## Setting up the Repository
+
+The following instructions include a few optional steps, they are by no means neccessary, or even
+recommended in some cases.
+
+ 1. [Fork the repository on GitHub][5] and clone it into a local directory. The following instructions
+    asume that you are in that directory.
+
+ 2. (optional) Add an upstream for the canonical repository this can be done using
+    `git remote add upstream git://github.com/codidact/core`. This can be very helpful for rebasing.
+
+## (optional) Setting up Visual Studio Code
+
+The following instructions are made very explicit for clarity, many of the steps can be done using
+shortcuts or by running a command directly.
+
+ 1. Go to `View > Extensions` and install the `ms-vscode.csharp` extension.
+
+ 2. Go to `File > Open Folder...` and open the directory into which you cloned your fork. There might
+    be some popups messages, ignore them and use the instructions below, this will ensure that we are
+    all on the same page.
+
+ 3. Go to `View > Command Palette...` and execute the `.NET: Generate Assets for Build and Debug` command.
+    You will be prompted to select a project, select `Codidact.WebUI`.
+
+ 4. New files should appear now, namely `.vscode/launch.json` and `.vscode/tasks.json`. These determine how
+    the project is build and launched. The default options are really good, however, I would recommend tinkering
+    until they match your personal preferences. Especially the option `logging.moduleLoad` is worth looking into,
+    refer to this [Stack Overflow question][1].
+
+ 5. More configuration can be done in `src/WebUI/Properties/launchSettings.json`, the defaults work though.
+
+ 6. Add your connection string to `src/WebUI/appsettings.Development.json`. This is how it could look like:
+
+    ~~~json
+    {
+        "Logging": {
+            "LogLevel": {
+                "Default": "Debug",
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Information"
+            }
+        },
+        "ConnectionStrings": {
+            "DefaultConnection": "Host=localhost;Database=codidact;Username=codidact"
+        }
+    }
+    ~~~
+
+ 7. You can run and debug the project by going to `Debug > Start Debugging`; a web browser should automatically open.
+
+ 8. In order to get IntelliSense (that is code completion as you type), go to `View > Command Palette...` and execute
+    `.NET: Restore All Projects`.
+
+ 9. It's currently not possible to run the tests from the editor directly, refer to the instructions for the command line.
+
+## (optional) Running the Project from the Command Line
+
+The following instructions assume that you are in the directory into which you cloned your fork.
+
+ 1. Add your connection string to `src/WebUI/appsettings.Development.json`, refer to the instructions for Visual Studio
+    Code.
+
+ 2. Change the configuration options in `src/WebUI/Properties/launchSettings.json` if you like, the defaults work though.
+
+ 3. You can launch the application by executing `dotnet run` in the `src/WebUI` directory.
+
+ 4. You can run the tests by executing `dotnet test` in the root directory.
+
+  [1]: https://stackoverflow.com/q/55683834/8746648
+  [2]: https://dotnet.microsoft.com/download/dotnet-core/3.1
+  [3]: https://code.visualstudio.com/
+  [4]: https://www.postgresql.org/download/
+  [5]: https://github.com/codidact/core

--- a/docs/linux-instructions.md
+++ b/docs/linux-instructions.md
@@ -1,61 +1,60 @@
-# Setup a Development Environment on Linux
+# Setting up a Development Environment on Linux
 
-## Requisites
+## Setting up the Database
 
- 1. Install the [.NET Core 3.1][2] framework, make sure to check if your package manager ships this version.
+ 1. Install [Postgres][4], the recommended way is to use your package manager.
 
- 2. Install [Postgres 12 or newer][4].
+ 2. Login as 'postgres' user, this can be done by executing `sudo -iu postgres`. The name could be
+    different for you, but the convention is that the user is called 'postgres'.
 
- 3. (optional) Install [Visual Studio Code][3], this is a text editor which works really well with C#
-    on Linux.
+ 3. Create a new user by executing `createuser codidact`, you can choose any name here.
 
-## Setup the Database
+ 4. Create a new database by executing `createdb --owner codidact codidact`, you can choose
+    any name here.
 
- 1. Login as `postgres` user, this is usally done by executing `sudo -iu postgres`.
+ 5. Prepare a connection string that will be used later. The format is
+    `Host=localhost;Database=X;Username=X`. If you honored the suggestions the connection
+    string would be `Host=localhost;Database=codidact;Username=codidact`.
 
- 2. Create a new user by executing `createuser codidact` you can choose any name here.
-
- 3. Create a new database by executing `createdb --owner codidact codidact` you can choose any name here.
-
- 4. Perpare a connection string by inserting your parameters into the format
-    `Host=localhost;Database=<database>;Username=<username>`, this is needed later. In the example above,
-    the connection string would be `Host=localhost;Database=codidact;Username=codidact`.
-
- 5. You can logout using `logout`.
+ 6. You can logout of the shell using `logout`.
 
 ## Setting up the Repository
 
-The following instructions include a few optional steps, they are by no means neccessary, or even
-recommended in some cases.
+ 1. [Fork the repository on GitHub][5] and clone it into a local directory.
 
- 1. [Fork the repository on GitHub][5] and clone it into a local directory. The following instructions
-    asume that you are in that directory.
+ 2. Navigate to that directory.
 
  2. (optional) Add an upstream for the canonical repository this can be done using
     `git remote add upstream git://github.com/codidact/core`. This can be very helpful for rebasing.
 
-## (optional) Setting up Visual Studio Code
+## Installation using Visual Studio Code
 
-The following instructions are made very explicit for clarity, many of the steps can be done using
-shortcuts or by running a command directly.
+ 1. Install the [.NET Core SDK][2] you need version 3.1, some package managers have a package for this.
 
- 1. Go to `View > Extensions` and install the `ms-vscode.csharp` extension.
+ 2. Install [Visual Studio Code][3]. You need the official version from Microsoft, the debugger
+    for C# isn't included in packages from your package manager.
 
- 2. Go to `File > Open Folder...` and open the directory into which you cloned your fork. There might
+The following instructions are expressed very verbosely, many things can be done quicker with
+shortcuts.
+
+ 3. Go to `View > Extensions` and install the `ms-vscode.csharp` extension. The extension will
+    automatically start installing dependencies.
+
+ 4. Go to `File > Open Folder...` and open the directory where you setup the repository. There might
     be some popups messages, ignore them and use the instructions below, this will ensure that we are
     all on the same page.
 
- 3. Go to `View > Command Palette...` and execute the `.NET: Generate Assets for Build and Debug` command.
+ 5. Go to `View > Command Palette...` and execute the `.NET: Generate Assets for Build and Debug` command.
     You will be prompted to select a project, select `Codidact.WebUI`.
 
- 4. New files should appear now, namely `.vscode/launch.json` and `.vscode/tasks.json`. These determine how
-    the project is build and launched. The default options are really good, however, I would recommend tinkering
-    until they match your personal preferences. Especially the option `logging.moduleLoad` is worth looking into,
-    refer to this [Stack Overflow question][1].
+ 6. New files should appear now, namely `.vscode/launch.json` and `.vscode/tasks.json`. These determine
+    how the project is built and launched. The default options are really good, however, I would
+    recommend tinkering until they match your personal preferences. Especially the option
+    `logging.moduleLoad` is worth looking into, refer to this [Stack Overflow question][1].
 
- 5. More configuration can be done in `src/WebUI/Properties/launchSettings.json`, the defaults work though.
+ 7. More configuration can be done in `src/WebUI/Properties/launchSettings.json`, the defaults work though.
 
- 6. Add your connection string to `src/WebUI/appsettings.Development.json`. This is how it could look like:
+ 8. Add your connection string to `src/WebUI/appsettings.Development.json`. This is how it could look like:
 
     ~~~json
     {
@@ -72,21 +71,26 @@ shortcuts or by running a command directly.
     }
     ~~~
 
- 7. You can run and debug the project by going to `Debug > Start Debugging`; a web browser should automatically open.
+ 9. You can launch the project by going to `Debug > Start Debugging`; a web browser should automatically open.
 
- 8. In order to get IntelliSense (that is code completion as you type), go to `View > Command Palette...` and execute
+10. In order to get IntelliSense (that is code completion as you type), go to `View > Command Palette...` and execute
     `.NET: Restore All Projects`.
 
- 9. It's currently not possible to run the tests from the editor directly, refer to the instructions for the command line.
+11. It's currently not possible to run the tests from the editor directly, refer to the instructions without
+    Visual Studio Code.
 
-## (optional) Running the Project from the Command Line
 
-The following instructions assume that you are in the directory into which you cloned your fork.
+## Installation without Visual Studio Code
 
- 1. Add your connection string to `src/WebUI/appsettings.Development.json`, refer to the instructions for Visual Studio
-    Code.
+ 1. Install the [.NET Core SDK][2] you need version 3.1, some package managers have a package for this.
 
- 2. Change the configuration options in `src/WebUI/Properties/launchSettings.json` if you like, the defaults work though.
+ 2. Navigate to the directory where you setup the repository.
+
+ 3. Add your connection string to `src/WebUI/appsettings.Development.json`, refer to the instructions
+    with Visual Studio Code.
+
+ 4. Change the configuration options in `src/WebUI/Properties/launchSettings.json` if you like, the
+    defaults work though.
 
  3. You can launch the application by executing `dotnet run` in the `src/WebUI` directory.
 

--- a/docs/windows-instructions.md
+++ b/docs/windows-instructions.md
@@ -1,0 +1,86 @@
+# Setting up a Development Environment on Windows
+
+## Setting up the Database
+
+ 1. Install Postgres, the recommended way is to use [the EnterpriseDB installer][5]. You need version
+    12 or newer.
+
+ 2. Start "pgAdmin", a web interface should open.
+
+ 3. Create a new user, this can be done by right-clicking on `Servers > PostgreSQL > Login/Group Roles`
+    and selecting `Create > Login/Group Role...`. You can choose any name, the instructions assume that
+    you choose "codidact". Make sure to select "Can login?" in the "Privileges" tab. It is necessary to
+    add a password to this account, do this in the "Definition" tab, the instructions assume that you choose
+    "codidact". *(Providing a password isn't necessary on Linux, but on Windows it is.
+    If you find a way to bypass this requirement, please create an issue.)*
+
+ 4. Create a new database, this can be done by right-clicking on `Servers > PostgreSQL > Databases` and
+    selecting `Create > Database...`. You can choose any name, the instructions assume that you choose
+    "codidact". Make sure that the owner is set to the user that you created before.
+
+ 5. Prepare a connection string for later use, the format is `Host=localhost;Database=X;Username=X;Password=X`.
+    If you honored the suggestions, you would have the connection string
+    `Host=localhost;Database=codidact;Username=codidact;Password=codidact`.
+
+## Installation using Visual Studio
+
+ 1. Install [Visual Studio][1] if you haven't already, the "Community" edition is sufficent.
+
+ 2. Ensure that the "ASP.NET and Web Development" workload is installed, this can be done during
+    installation or later by starting the "Visual Studio Installer" application and selecting
+    "Modify".
+
+ 3. Next, clone the repository. This can be done using Visual Studio by selecting "Clone or check out code"
+    in the launcher. Alternativly, you can clone the repository manually with [Git for Windows][3]. The
+    URL is `https://github.com/codidact/core`.
+
+ 4. Create a new branch, note that there is a [naming convention for branches][4]. This can be done at the bottom right of
+    the screen, by clicking on the current branch and selecting `New Branch...`.
+
+ 5. For some reason Visual Studio opens the repository as folder and not as a solution. It's not possible
+    to launch the application in this state. There should be a popup message in the solution explorer
+    to "Switch Views", do that.
+
+ 6. In `src/WebUI` edit the `appsettings.Development.json` file. Visual Studio likes to hide this file, you
+    can reveal it by pressing the arrow button next to the `appsettings.json` file. Add your connection string,
+    the edited file should look something like this:
+
+    ~~~json
+    {
+        "ConnectionStrings": {
+            "DefaultConnection": "Host=localhost;Database=codidact;Username=codidact;Password=codidact"
+        },
+        "Logging": {
+            "LogLevel": {
+                "Default": "Information",
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Information"
+            }
+        }
+    }
+    ~~~
+
+ 7. You can launch the application by clicking `Debug > Start Debugging`.
+
+ 8. You can run the integration tests by clicking `Test > Run all Tests`.
+
+## Installation without Visual Studio
+
+ 1. Install the [.NET Core SDK][2] this is not necessary if you have Visual Studio with the
+    required workload installed. You need version 3.1 or newer.
+
+ 2. Install [Git for Windows][3] and clone the repository somewhere, the URL is `https://github.com/codidact/core`.
+
+ 3. Create a new branch, notice that there is a [naming convention for branches][4].
+
+ 4. Setup the `appsettings.Development.json` file in `src/WebUI`, refer to the instructions for Visual Studio.
+
+ 5. You can launch the appliation by executing `dotnet run` in the `src/WebUI` directory.
+
+ 6. You can run the integration tests using `dotnet test` in the root directory.
+
+  [1]: https://visualstudio.microsoft.com/downloads/
+  [2]: https://dotnet.microsoft.com/download
+  [3]: https://git-scm.com/download/win
+  [4]: https://github.com/codidact/core/blob/develop/CONTRIBUTING.md#whats-the-workflow
+  [5]: https://www.enterprisedb.com/downloads/postgres-postgresql-downloads


### PR DESCRIPTION
This is essentially #28 but I renamed the branch from `asynts/linux-instructions` to `asynts/instructions`. I don't know if it's possible to rename a branch while a pull request is open, and didn't want to try it out in a live environment.

It would be really helpful if someone independently tested the instructions.