### PR TITLE
Jflopezfernandez/36/populate privacy policy page

### DIFF
--- a/src/WebUI/Views/Home/Privacy.cshtml
+++ b/src/WebUI/Views/Home/Privacy.cshtml
@@ -3,4 +3,65 @@
 }
 <h1>@ViewData["Title"]</h1>
 
-<p>Use this page to detail your site's privacy policy.</p>
+<h2>What information do we collect?</h2>
+
+<p>We collect information from you when you register on our site and gather data when you participate in the forum by reading, writing, and evaluating the content shared here.</p>
+
+<p>When registering on our site, you may be asked to enter your name and e-mail address. You may, however, visit our site without registering. Your e-mail address will be verified by an email containing a unique link. If that link is visited, we know that you control the e-mail address.</p>
+
+<p>When registered and posting, we record the IP address that the post originated from. We also may retain server logs which include the IP address of every request to our server.</p>
+
+<p>We also collect information through Matomo, a privacy-respecting analytics service. This information is not available to any third party, including Matomo themselves; all collected data remains under our control.</p>
+
+<h2>What do we use your information for?</h2>
+
+<p>Any of the information we collect from you may be used in one of the following ways:</p>
+
+<ul>
+    <li>To personalize your experience — your information helps us to better respond to your individual needs.</li>
+    <li>To improve our site — we continually strive to improve our site offerings based on the information and feedback we receive from you.</li>
+    <li>To send periodic emails — The email address you provide may be used to send you information, notifications that you request about changes to topics or in response to your user name, respond to inquiries, and/or other requests or questions.</li>
+</ul>
+
+<h2>How do we protect your information?</h2>
+
+<p>We implement a variety of security measures to maintain the safety of your personal information when you enter, submit, or access your personal information.</p>
+
+<h2>What is our data retention policy?</h2>
+
+<p>We will make a good faith effort to:</p>
+
+<ul>
+    <li>Retain server logs containing the IP address of all requests to this server no more than 90 days.</li>
+    <li>Retain the IP addresses associated with registered users and their posts no more than 5 years.</li>
+</ul>
+
+<h2>Do we use cookies?</h2>
+
+<p>Yes. Cookies are small files that a site or its service provider transfers to your computer’s hard drive through your Web browser (if you allow). These cookies enable the site to recognize your browser and, if you have a registered account, associate it with your registered account.</p>
+
+<p>We use cookies to understand and save your preferences for future visits and compile aggregate data about site traffic and site interaction so that we can offer better site experiences and tools in the future. We may contract with third-party service providers to assist us in better understanding our site visitors. These service providers are not permitted to use the information collected on our behalf except to help us conduct and improve our business.</p>
+
+<h2>Do we disclose any information to outside parties?</h2>
+
+<p>We do not sell, trade, or otherwise transfer to outside parties your personally identifiable information. This does not include trusted third parties who assist us in operating our site, conducting our business, or servicing you, so long as those parties agree to keep this information confidential. We may also release your information when we believe release is appropriate to comply with the law, enforce our site policies, or protect ours or others rights, property, or safety. However, non-personally identifiable visitor information may be provided to other parties for marketing, advertising, or other uses.</p>
+
+<h2>Third party links</h2>
+
+<p>Occasionally, at our discretion, we may include or offer third party products or services on our site. These third party sites have separate and independent privacy policies. We therefore have no responsibility or liability for the content and activities of these linked sites. Nonetheless, we seek to protect the integrity of our site and welcome any feedback about these sites.</p>
+
+<h2>Children’s Online Privacy Protection Act Compliance</h2>
+
+<p>Our site, products and services are all directed to people who are at least 13 years old or older. If this server is in the USA, and you are under the age of 13, per the requirements of COPPA (Children’s Online Privacy Protection Act), do not use this site.</p>
+
+<h2>Online Privacy Policy Only</h2>
+
+<p>This online privacy policy applies only to information collected through our site and not to information collected offline.</p>
+
+<h2>Your Consent</h3>
+
+<p>By using our site, you consent to our web site privacy policy.</p>
+
+<h2>Changes to our Privacy Policy</h2>
+
+<p>If we decide to change our privacy policy, we will post those changes on this page.</p>

--- a/src/WebUI/appsettings.Development.json
+++ b/src/WebUI/appsettings.Development.json
@@ -5,8 +5,5 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  },
-  "ConnectionStrings": {
-      "DefaultConnection": "Host=localhost;Database=codidact;Username=codidact"
   }
 }

--- a/src/WebUI/appsettings.Development.json
+++ b/src/WebUI/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "ConnectionStrings": {
+      "DefaultConnection": "Host=localhost;Database=codidact;Username=codidact"
   }
 }


### PR DESCRIPTION
## Fixes Issue #36 

This commit populates the site privacy policy page with the privacy policy from [the forum](https://forum.codidact.org/privacy). No modifications were made to the privacy policy, I simply copied and pasted it, and then added basic html markup to each element.

![Updated Privacy Policy Page](https://i.imgur.com/LIZQ5F2.png)