### PR TITLE
linter

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "dotnet-ef"
       ]
-    }
+    },
+	"dotnet-format": {
+		"version": "3.2.107702",
+		"commands": [
+			"dotnet-format"
+		]
+	}
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,123 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+# All files 
+[*] 
+indent_style = space 
+# Code files 
+[*.{cs,csx,vb,vbx}] 
+indent_size = 4 
+insert_final_newline = true 
+charset = utf-8-bom 
+############################### 
+# .NET Coding Conventions     # 
+############################### 
+[*.{cs,vb}] 
+# Organize usings 
+dotnet_sort_system_directives_first = true 
+# this. preferences 
+dotnet_style_qualification_for_field = false:silent 
+dotnet_style_qualification_for_property = false:silent 
+dotnet_style_qualification_for_method = false:silent 
+dotnet_style_qualification_for_event = false:silent 
+# Language keywords vs BCL types preferences 
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent 
+dotnet_style_predefined_type_for_member_access = true:silent 
+# Parentheses preferences 
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent 
+# Modifier preferences 
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent 
+dotnet_style_readonly_field = true:suggestion 
+# Expression-level preferences 
+dotnet_style_object_initializer = true:suggestion 
+dotnet_style_collection_initializer = true:suggestion 
+dotnet_style_explicit_tuple_names = true:suggestion 
+dotnet_style_null_propagation = true:suggestion 
+dotnet_style_coalesce_expression = true:suggestion 
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent 
+dotnet_prefer_inferred_tuple_names = true:suggestion 
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion 
+dotnet_style_prefer_auto_properties = true:silent 
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent 
+dotnet_style_prefer_conditional_expression_over_return = true:silent 
+############################### 
+# Naming Conventions          # 
+############################### 
+# Style Definitions 
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case 
+# Use PascalCase for constant fields   
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style 
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field 
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = * 
+dotnet_naming_symbols.constant_fields.required_modifiers          = const 
+############################### 
+# C# Coding Conventions       # 
+############################### 
+[*.cs] 
+# var preferences 
+csharp_style_var_for_built_in_types = true:silent 
+csharp_style_var_when_type_is_apparent = true:silent 
+csharp_style_var_elsewhere = true:silent 
+# Expression-bodied members 
+csharp_style_expression_bodied_methods = false:silent 
+csharp_style_expression_bodied_constructors = false:silent 
+csharp_style_expression_bodied_operators = false:silent 
+csharp_style_expression_bodied_properties = true:silent 
+csharp_style_expression_bodied_indexers = true:silent 
+csharp_style_expression_bodied_accessors = true:silent 
+# Pattern matching preferences 
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion 
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion 
+# Null-checking preferences 
+csharp_style_throw_expression = true:suggestion 
+csharp_style_conditional_delegate_call = true:suggestion 
+# Modifier preferences 
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion 
+# Expression-level preferences 
+csharp_prefer_braces = true:silent 
+csharp_style_deconstructed_variable_declaration = true:suggestion 
+csharp_prefer_simple_default_expression = true:suggestion 
+csharp_style_pattern_local_over_anonymous_function = true:suggestion 
+csharp_style_inlined_variable_declaration = true:suggestion 
+############################### 
+# C# Formatting Rules         # 
+############################### 
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+csharp_new_line_before_else = true 
+csharp_new_line_before_catch = true 
+csharp_new_line_before_finally = true 
+csharp_new_line_before_members_in_object_initializers = true 
+csharp_new_line_before_members_in_anonymous_types = true 
+csharp_new_line_between_query_expression_clauses = true 
+# Indentation preferences 
+csharp_indent_case_contents = true 
+csharp_indent_switch_labels = true 
+csharp_indent_labels = flush_left 
+# Space preferences 
+csharp_space_after_cast = false 
+csharp_space_after_keywords_in_control_flow_statements = true 
+csharp_space_between_method_call_parameter_list_parentheses = false 
+csharp_space_between_method_declaration_parameter_list_parentheses = false 
+csharp_space_between_parentheses = false 
+csharp_space_before_colon_in_inheritance_clause = true 
+csharp_space_after_colon_in_inheritance_clause = true 
+csharp_space_around_binary_operators = before_and_after 
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false 
+csharp_space_between_method_call_name_and_opening_parenthesis = false 
+csharp_space_between_method_call_empty_parameter_list_parentheses = false 
+# Wrapping preferences 
+csharp_preserve_single_line_statements = true 
+csharp_preserve_single_line_blocks = true 
+############################### 
+# VB Coding Conventions       # 
+############################### 
+[*.vb] 
+# Modifier preferences 
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion 

--- a/src/Domain/Entities/Member.cs
+++ b/src/Domain/Entities/Member.cs
@@ -13,7 +13,7 @@ namespace Codidact.Domain.Entities
         /// Auto Incremented Identification number
         /// </summary>
         public long Id { get; set; }
-        
+
         /// <summary>
         /// The display name that is to be displayed for the member
         /// </summary>

--- a/src/Domain/Entities/TrustLevel.cs
+++ b/src/Domain/Entities/TrustLevel.cs
@@ -11,12 +11,12 @@ namespace Codidact.Domain.Entities
         /// Auto Incremented Identification number
         /// </summary>
         public long Id { get; set; }
-       
+
         /// <summary>
         /// Name of the trust level
         /// </summary>
         public string Name { get; set; }
-        
+
         /// <summary>
         /// A short explaination of this trust level and its meaning
         /// </summary>

--- a/src/Domain/Extensions/StringExtensions.cs
+++ b/src/Domain/Extensions/StringExtensions.cs
@@ -11,7 +11,8 @@ namespace Codidact.Domain.Extensions
         /// <returns></returns>
         public static string ToSnakeCase(this string input)
         {
-            if (string.IsNullOrEmpty(input)) { 
+            if (string.IsNullOrEmpty(input))
+            {
                 return input;
             }
 

--- a/src/WebUI/Models/ErrorViewModel.cs
+++ b/src/WebUI/Models/ErrorViewModel.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace Codidact.WebUI.Models
 {
     public class ErrorViewModel

--- a/src/WebUI/Program.cs
+++ b/src/WebUI/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/src/WebUI/Startup.cs
+++ b/src/WebUI/Startup.cs
@@ -1,4 +1,4 @@
-using Codidact.Application;
+﻿using Codidact.Application;
 using Codidact.Infrastructure;
 using Codidact.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Builder;


### PR DESCRIPTION
Added `dotnet-format`
Ran `dotnet-format` (a few minor whitespace changes)
Added the default `.editorconfig`

Relates to: https://github.com/codidact/core/issues/26

Notes:
There is no way to check for violations without automatically fixing them using this tool. 
For example, we may want to run a check and fail before tests are run, or before a deploy. Rather than asking contributors to run it before/after a merge request.